### PR TITLE
add-to-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6786,11 +6786,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8022,21 +8017,6 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true
-    },
-    "tmdbv3": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tmdbv3/-/tmdbv3-0.1.2.tgz",
-      "integrity": "sha1-mOnyMSUIDSyGKpb9ykzxrTb0bwg=",
-      "requires": {
-        "request": "2.9.x"
-      },
-      "dependencies": {
-        "request": {
-          "version": "2.9.203",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
-          "integrity": "sha1-bBcRpUB/uUoRQhlWPkQUW8v0cjo="
-        }
-      }
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     "body-scroll-lock": "^4.0.0-beta.0",
     "firebase": "^9.6.3",
     "notiflix": "^3.2.2",
-    "prettier": "^2.5.1",
-    "tmdbv3": "^0.1.2",
     "tui-pagination": "^3.4.1",
     "vanilla-back-to-top": "^7.2.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import './js/search';
 import './js/spinner';
 
 import './js/api-service';
+import './js/get-movies-from-storage';
+import './js/reload-library-page';
 import './js/pagination';
 import './js/watched-queue';
 import './js/authorization';

--- a/src/js/get-movies-from-storage.js
+++ b/src/js/get-movies-from-storage.js
@@ -1,0 +1,14 @@
+const QUEUE = 'queueList';
+const WATCHED = 'watchedList';
+
+export default {
+  getMoviesFromQueueStorage() {
+    return getMoviesFromStorage(QUEUE)
+  },
+    getMoviesFromWatchedStorage() {
+    return getMoviesFromStorage(WATCHED)
+  },
+}
+function getMoviesFromStorage(list) {
+  return JSON.parse(localStorage.getItem(list));
+}

--- a/src/js/reload-library-page.js
+++ b/src/js/reload-library-page.js
@@ -1,0 +1,50 @@
+import filmCardsTpl from '../templates/film-template.hbs';
+import moviesFromStorage from './get-movies-from-storage';
+const API_KEY = '1aaaa4b4eb79ea073919ef453434f2ea';
+const BASE_URL = 'https://api.themoviedb.org/3/movie/';
+import axios from 'axios';
+
+const refs = {
+    libraryPageContainer: document.querySelector('.library-filter'),
+    headerQueueBtn: document.querySelector('.queue-link'),
+    libraryFilmCards: document.querySelector('.movies-list'), 
+};
+async function MovieById(id) {
+  try {
+    const { data } = await axios.get(`${BASE_URL}${id}?api_key=${API_KEY}`);
+    
+    return data;
+  } catch (error) {
+    console.log(error);
+  }
+}
+MovieById().then(list => {
+    JSON.parse(localStorage.getItem(list))
+  }).then(data =>{console.log(data)})
+
+  const { getMoviesFromQueueStorage, getMoviesFromWatchedStorage } = moviesFromStorage;
+
+
+  export default function () {
+    if (refs.libraryPageContainer.classList.contains('is-hidden')) {
+      return
+    }
+    if (refs.headerQueueBtn.classList.contains('library-filter')) {
+      const films = getMoviesFromQueueStorage();
+      filmCardsTpl(refs.libraryFilmCards, films);
+      
+      if (films.length === 0) {onEmptyLibrary()}
+      return
+    }
+    const films = getMoviesFromWatchedStorage();
+    filmCardsTpl(refs.libraryFilmCards, films);
+    if (films.length === 0) {onEmptyLibrary()}
+  }
+
+  function onEmptyLibrary() {
+      //пустая библиотека
+    const markupLibrary = `<h2>Please return to the main page and add a movie...</h2>`;
+    //отрисованая из локал сторедж
+    refs.libraryFilmCards.innerHTML = markupLibrary;
+    refs.libraryFilmCards.classList.add('library-filter');
+  }

--- a/src/js/watched-queue.js
+++ b/src/js/watched-queue.js
@@ -1,201 +1,103 @@
-import moviesTemplate from '../templates/film-template.hbs';
-const API_KEY = '1aaaa4b4eb79ea073919ef453434f2ea';
-const BASE_URL = 'https://api.themoviedb.org/3/';
-const axios = require('axios');
+export default function (data) {
+  const addToWatched = document.querySelector('[data-action="add-to-watched"]')
+  const addToQueue = document.querySelector('[data-action="add-to-queue"]')
 
-const dataDiv = document.querySelector('.movies-list');
+  let watchedList = JSON.parse(localStorage.getItem(`watchedList`)) || []
+  let queueList = JSON.parse(localStorage.getItem(`queueList`)) || []
 
-const Watched = [];
+  let indexOfElWatched = 0
+  let indexOfElQueue = 0
 
-const Queued = [];
+  function checkButton() {
+    watchedList.forEach((element, i) => {
+      if (element.id === data.id) {
+        addToWatched.textContent = 'REMOVE FROM WATCHED'
+        indexOfElWatched = i
+      } 
+    })
 
-async function fetchMovies() {
-  const response = await fetch(`${BASE_URL}trending/all/day?api_key=${API_KEY}`);
-  const data = await response.json();
-  console.log(data.results);
-  dataDiv.insertAdjacentHTML('afterbegin', moviesTemplate(data.results));
+    queueList.forEach((element, i) => {
+      if (element.id === data.id) {
+        addToQueue.textContent = 'REMOVE FROM QUEUE'
+        indexOfElQueue = i
+    } 
+    })
+  }
+  checkButton()
+  chekBtnStatus()
+  function addToLocalStorageWatched() {
+    if (addToWatched.textContent === 'REMOVE FROM WATCHED') {
+      watchedList.splice(indexOfElWatched, 1)
+      localStorage.setItem(`watchedList`, JSON.stringify(watchedList))
+      addToWatched.textContent = 'ADD TO WATCHED'
+      checkButton()
+      chekBtnStatus()
+    } else
+      if (addToQueue.textContent === 'ADD TO QUEUE') {
+        watchedList.push(data)
+        let watchedStr = JSON.stringify(watchedList)
+        localStorage.setItem(`watchedList`, watchedStr)
 
-  // getClickedElem()
-  getButtonWatched();
-  getButtonQueued();
-  return data;
-}
+        console.log("addToWatched");
 
-function addArrayToLocalStorage(array) {
-  localStorage.setItem('Watched', JSON.stringify(array));
-  localStorage.setItem('Queued', JSON.stringify(array));
-}
-// fetchMovies(550)
-
-addArrayToLocalStorage([]);
-
-function addToWatched(e) {
-  fetchMovies(550).then(data => {
-    data.results.forEach(element => {
-      if (+e.srcelementent.parentElement.attributes.value.value === element.id) {
-        try {
-          const savedData = localStorage.getItem('Watched');
-          const parsedData = JSON.parse(savedData);
-
-          parsedData.push(element);
-          localStorage.setItem('Watched', JSON.stringify(parsedData));
-          console.log(element, parsedData);
-        } catch (error) {
-          console.log(error);
-        }
+        checkButton()
+        chekBtnStatus()
+      } else {
+        console.log("alreadyInQueued")
       }
-    });
-  });
-}
+      reloadLibraryPage()
+     }
 
-function addToQueued(e) {
-  fetchMovies(550).then(data => {
-    data.results.forEach(element => {
-      if (+e.srcelementent.parentElement.attributes.value.value === element.id) {
-        try {
-          const savedData = localStorage.getItem('Queued');
-          const parsedData = JSON.parse(savedData);
+  function addToLocalStorageQueue() {
+    if (addToQueue.textContent === 'REMOVE FROM QUEUE') {
 
-          parsedData.push(element);
-          localStorage.setItem('Queued', JSON.stringify(parsedData));
-        } catch (error) {
-          console.log(error);
-        }
+      queueList.splice(indexOfElQueue, 1)
+      localStorage.setItem(`queueList`, JSON.stringify(queueList))
+      addToQueue.textContent = 'ADD TO QUEUE'
+      console.log("removeFromQueue")
+      checkButton()
+    chekBtnStatus()
+    } else
+      if (addToWatched.textContent === 'ADD TO WATCHED') {
+        queueList.push(data)
+        let queueStr = JSON.stringify(queueList)
+        localStorage.setItem(`queueList`, queueStr)
+        console.log("addToQueue")
+      checkButton()
+      chekBtnStatus()
       }
-    });
-  });
-}
-
-function getButtonWatched() {
-  const buttonWatched = document.querySelectorAll('.watched-link');
-  buttonWatched.forEach(element => element.addEventListener('click', addToWatched));
-}
-function getButtonQueued() {
-  const buttonQueued = document.querySelectorAll('queue-link');
-  buttonQueued.forEach(element => element.addEventListener('click', addToQueued));
-}
-
-// export default function (data) {
-//   const addToWatched = document.querySelector('.modal__watch-list')
-//   const addToQueue = document.querySelector('.modal__queue-list')
-
-//   let watchedList = JSON.parse(localStorage.getItem(`watchedList`)) || []
-//   let queueList = JSON.parse(localStorage.getItem(`queueList`)) || []
-
-//   let indexOfElWatched = 0
-//   let indexOfElQueue = 0
-
-//   function checkButton() {
-//     watchedList.forEach((element, i) => {
-//       if (element.id === data.id) {
-//         addToWatched.textContent = 'REMOVE FROM WATCHED'
-//         indexOfElWatched = i
-//       }
-//     })
-
-//     queueList.forEach((element, i) => {
-//       if (element.id === data.id) {
-//         addToQueue.textContent = 'REMOVE FROM QUEUE'
-//         indexOfElQueue = i
-//     }
-//     })
-//   }
-
-//   checkButton()
-//   chekBtnStatus()
-//   function addToLocalStorageWatched() {
-//     if (addToWatched.textContent === 'REMOVE FROM WATCHED') {
-//       watchedList.splice(indexOfElWatched, 1)
-//       localStorage.setItem(`watchedList`, JSON.stringify(watchedList))
-//       addToWatched.textContent = 'ADD TO WATCHED'
-
-//       // setTimeout(e => {
-//       //   notifications.removeFromWatched()
-//       // }, 1000)
-//       checkButton()
-//       chekBtnStatus()
-//     } else
-//       if (addToQueue.textContent === 'ADD TO QUEUE') {
-//         watchedList.push(data)
-//         let watchedStr = JSON.stringify(watchedList)
-//         localStorage.setItem(`watchedList`, watchedStr)
-
-//         setTimeout(e => {
-//           notifications.addToWatched()
-//         }, 500)
-
-//         checkButton()
-//         chekBtnStatus()
-//       } else {
-//         // setTimeout(e => {
-//         //   notifications.alreadyInQueued()
-//         // }, 1000)
-
-//       }
-//       reloadLibraryPage()
-//      }
-
-//   function addToLocalStorageQueue() {
-//     if (addToQueue.textContent === 'REMOVE FROM QUEUE') {
-
-//       queueList.splice(indexOfElQueue, 1)
-//       localStorage.setItem(`queueList`, JSON.stringify(queueList))
-//       addToQueue.textContent = 'ADD TO QUEUE'
-
-//       // setTimeout(e => {
-//       //   notifications.removeFromQueue()
-//       // }, 1000)
-
-//       checkButton()
-//     chekBtnStatus()
-//     } else
-//       if (addToWatched.textContent === 'ADD TO WATCHED') {
-//         queueList.push(data)
-//         let queueStr = JSON.stringify(queueList)
-//         localStorage.setItem(`queueList`, queueStr)
-//         setTimeout(e => {
-//           notifications.addToQueue()
-//         }, 500)
-
-//       checkButton()
-//       chekBtnStatus()
-//       }
-//       else {
-
-//         // setTimeout(e => {
-//         //   notifications.alreadyInWatched()
-//         // }, 1000)
-
-//       }
-//       reloadLibraryPage()
-//      }
-
-//   function chekBtnStatus() {
-//     if ((addToQueue.textContent === 'ADD TO QUEUE') && (addToWatched.textContent === 'REMOVE FROM WATCHED')) {
-//       addToQueue.setAttribute('disabled', true)
-//       addToQueue.style.cursor = 'not-allowed'
-//       addToQueue.classList.remove('modal__queue-list')
-//       addToQueue.classList.add('disabled')
-//     } else {
-//       addToQueue.removeAttribute('disabled', false)
-//       addToQueue.style.cursor = 'pointer'
-//        addToQueue.classList.remove('disabled')
-//       addToQueue.classList.add('modal__queue-list')
-//     }
-//     if ((addToWatched.textContent === 'ADD TO WATCHED') && (addToQueue.textContent === 'REMOVE FROM QUEUE')) {
-//       addToWatched.setAttribute('disabled', true)
-//       addToWatched.style.cursor = 'not-allowed'
-//        addToWatched.classList.remove('modal__watch-list')
-//       addToWatched.classList.add('disabled')
-//     } else {
-//       addToWatched.removeAttribute('disabled', false)
-//       addToWatched.style.cursor = 'pointer'
-//        addToWatched.classList.remove('disabled')
-//       addToWatched.classList.add('modal__watch-list')
-//     }
-//   }
-
-//   addToWatched.addEventListener(`click`, addToLocalStorageWatched)
-//   addToQueue.addEventListener('click', addToLocalStorageQueue)
-
-//   }
+      else {
+        console.log("alreadyInWatched");
+      }
+// смена списка библиотеки добавленых/просмотреных
+      reloadLibraryPage()
+     }
+//Смена статуса кнопок
+  function chekBtnStatus() {
+    if ((addToQueue.textContent === 'ADD TO QUEUE') && (addToWatched.textContent === 'REMOVE FROM WATCHED')) {
+      addToQueue.setAttribute('disabled', true)
+      addToQueue.style.cursor = 'not-allowed'
+      addToQueue.classList.remove('modal__queue-list')
+      addToQueue.classList.add('disabled')
+    } else {
+      addToQueue.removeAttribute('disabled', false)
+      addToQueue.style.cursor = 'pointer'
+       addToQueue.classList.remove('disabled')
+      addToQueue.classList.add('modal__queue-list')
+    }
+    if ((addToWatched.textContent === 'ADD TO WATCHED') && (addToQueue.textContent === 'REMOVE FROM QUEUE')) {
+      addToWatched.setAttribute('disabled', true)
+      addToWatched.style.cursor = 'not-allowed'
+       addToWatched.classList.remove('modal__watch-list')
+      addToWatched.classList.add('disabled')
+    } else {
+      addToWatched.removeAttribute('disabled', false)
+      addToWatched.style.cursor = 'pointer'
+       addToWatched.classList.remove('disabled')
+      addToWatched.classList.add('modal__watch-list')
+    }
+  }
+  // добавление в просмотренные ы список 
+  addToWatched.addEventListener(`click`, addToLocalStorageWatched)
+  addToQueue.addEventListener('click', addToLocalStorageQueue)
+  }

--- a/src/templates/film-template.hbs
+++ b/src/templates/film-template.hbs
@@ -1,11 +1,14 @@
 {{#each this}}
-<div class="movie-wrapper" value={{id}}></div>
     <li class="movies-list__item">
         <a class="movies-list__link" href="#">
-            <img class="movies-list__image" src="https://image.tmdb.org/t/p/original/{{poster_path}}" loading="eager" alt="{{original_title}}">
+            {{#if poster_path}}
+            <img class="movies-list__image" src="https://image.tmdb.org/t/p/original/{{poster_path}}" loading="eager" alt="{{original_title}}"  data-id="{{id}}">
+            {{else}}
+            <img class="movies-list__image" src="https://raw.githubusercontent.com/dariaddz/DigitalUnicorns-Filmoteka/main/src/images/no-poster_1x.jpg" loading="lazy" alt="{{original_title}}" data-id="{{id}}">
+            {{/if}}
             <div class="movies-list__container">
-                <h3 class="movies-list__title">{{original_title}}</h3>
-                <p class="movies-list__description">{{#each genre_ids}} {{this}} {{/each}} | {{release_date}}
+                <h3 data-id="{{id}}" class="movies-list__title">{{original_title}}</h3>
+                <p class="movies-list__description">{{#each genre_ids}}{{this}}{{#unless @last}}, {{/unless}}{{/each}} | {{release_date}}
                     <span>{{vote_average}}</span>
                 </p>
             </div>


### PR DESCRIPTION
Добавила через  через  дефолтный експорт потому, как при логике отрисовки возможно чем то нужно будет пользоваться 
watched-queue   
На кнопки с модалки  я стучалась через data-action= но при формировании списков класс add-to-library возможно разделить на  modal__watch-list и  modal__queue-list
Чтоб разделить формирование списков…ну или может какой –нибудь другой вариант
 get-movies-from-storage  функции которые вытягивают список из локал сторедж 
reload-library-page отрисовка разметки из списков локар сторедж

